### PR TITLE
feat: switch ArgoCD ALB to internal and add private Route 53 zone #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/ConsciousML/terragrunt-template-catalog-eks/actions/workflows/ci.yaml/badge.svg)](https://github.com/ConsciousML/terragrunt-template-catalog-eks/actions/workflows/ci.yaml)
 [![PR's Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
 
-A Terragrunt Template Catalog for production Infrastructure as Code (IaC) on Amazon Web Services (AWS).
+A Terragrunt Template Catalog for EKS production Infrastructure as Code (IaC)
 
 ## Catalog vs Live Infrastructure
 
@@ -29,7 +29,7 @@ Modules (modules/) → Units (units/) → Stacks (stacks/) → Examples (pipelin
 - **[Units](units/README.md)**: Terragrunt wrappers around modules that add configuration and dependencies
 - **[Stacks](stacks/README.md)**: Collections of units arranged in dependency graphs for pattern level re-use
 - **[Examples](pipelines/examples/README.md)**: Simple configuration for testing and development
-- **[Bootstrap](pipelines/bootstrap/)**: Contains pipelines that need to be run once per repository fork (authenticating GitHub Actions with AWS and create a Route 53 hosted zone to host the ArgoCD UI on our domain). 
+- **[Bootstrap](pipelines/bootstrap/)**: Contains pipelines that need to be run once per repository fork for authenticating GitHub Actions with AWS and creating a [Route 53](https://aws.amazon.com/route53/) [hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) to sign TLS certificates with [AWS ACM](https://aws.amazon.com/certificate-manager/)
 - **[CI](docs/continuous-integration.md)**: Automated configuration validation, testing (`terratest`) and documatentation (`terraform-docs`).
 
 ## Getting Started
@@ -43,7 +43,7 @@ First, you'll need to fork this repository and make a few changes:
 1. Click on `Use this template` to create your own repository
 2. Use your IDE of choice to replace every occurrence of `github.com/ConsciousML/terragrunt-template-catalog-eks` and `git::git@github.com:ConsciousML/terragrunt-template-catalog-eks.git` by your GitHub repo URL following the same format
 3. Change `pipelines/region.hcl` to match your desired AWS region
-4. Change `pipelines/dns_config.hcl` to match your domain name where you'll deploy ArgoCD (if you don't have a domain name, you'll need to register one using a domain registrar such a GoDaddy or Namecheap)
+4. Change `pipelines/dns_config.hcl` to match your domain name where you'll use ACM to sign TLS certificates (if you don't have a domain name, you'll need to register one using a domain registrar such a GoDaddy or Namecheap)
 
 **Warning**: If you skip step 2, the TG source links will still point to the original repository (on `github.com/ConsciousML/`).
 
@@ -97,7 +97,9 @@ aws configure
 For more information, read the [AWS CLI authentication documentation](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 ### Run the Bootstrap Pipelines
-Follow the [enable Terragrunt in GitHub Actions](pipelines/bootstrap/enable_tg_github_actions/README.md) and [Setup DNS](pipelines/bootstrap/setup_dns/README.md) documentation to authenticate CI/CD with AWS and to setup your hosted zone to deploy ArgoCD under a Rout53 DNS.
+Follow the [enable Terragrunt in GitHub Actions](pipelines/bootstrap/enable_tg_github_actions/README.md) and [Setup DNS](pipelines/bootstrap/setup_dns/README.md) documentation to authenticate CI/CD with AWS and to setup your hosted zone to sign TLS certificates with ACM
+
+
 
 ### Deploy a Dev EKS Cluster
 

--- a/modules/route53_hosted_zone/README.md
+++ b/modules/route53_hosted_zone/README.md
@@ -1,9 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # AWS Route53 Hosted Zone Module
 
-This module creates a Route53 public hosted zone for a given domain name.
-
-After applying, retrieve the `name_servers` output and add all 4 NS records to your domain registrar before running any stack that depends on DNS validation (e.g. ACM certificate issuance).
+This module creates or looks up a Route53 hosted zone. Supports both public zones (internet-facing, requires NS delegation for ACM validation) and private zones (VPC-scoped, no delegation required).
 
 ## Requirements
 
@@ -32,7 +30,9 @@ After applying, retrieve the `name_servers` output and add all 4 NS records to y
 | <a name="input_comment"></a> [comment](#input\_comment) | A comment for the hosted zone | `string` | `"Managed by Terraform"` | no |
 | <a name="input_create"></a> [create](#input\_create) | If true, create the hosted zone. If false, look it up via data source (zone must already exist). | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the hosted zone (e.g. example.com) | `string` | n/a | yes |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | If true, the hosted zone is private. Used for data source lookup when create = false. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the hosted zone | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate with the hosted zone. When set, the created zone is private. Only used when create = true. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/route53_hosted_zone/header.md
+++ b/modules/route53_hosted_zone/header.md
@@ -1,5 +1,3 @@
 # AWS Route53 Hosted Zone Module
 
-This module creates a Route53 public hosted zone for a given domain name.
-
-After applying, retrieve the `name_servers` output and add all 4 NS records to your domain registrar before running any stack that depends on DNS validation (e.g. ACM certificate issuance).
+This module creates or looks up a Route53 hosted zone. Supports both public zones (internet-facing, requires NS delegation for ACM validation) and private zones (VPC-scoped, no delegation required).

--- a/modules/route53_hosted_zone/main.tf
+++ b/modules/route53_hosted_zone/main.tf
@@ -3,10 +3,17 @@ resource "aws_route53_zone" "this" {
   name    = var.name
   comment = var.comment
   tags    = var.tags
+
+  dynamic "vpc" {
+    for_each = var.vpc_id != null ? [var.vpc_id] : []
+    content {
+      vpc_id = vpc.value
+    }
+  }
 }
 
 data "aws_route53_zone" "this" {
   count        = var.create ? 0 : 1
   name         = var.name
-  private_zone = false
+  private_zone = var.private_zone
 }

--- a/modules/route53_hosted_zone/variables.tf
+++ b/modules/route53_hosted_zone/variables.tf
@@ -25,3 +25,15 @@ variable "create" {
   type        = bool
   default     = true
 }
+
+variable "private_zone" {
+  description = "If true, the hosted zone is private. Used for data source lookup when create = false."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID to associate with the hosted zone. When set, the created zone is private. Only used when create = true."
+  type        = string
+  default     = null
+}

--- a/pipelines/bootstrap/setup_dns/README.md
+++ b/pipelines/bootstrap/setup_dns/README.md
@@ -1,19 +1,28 @@
 # DNS Bootstrap
 
-Creates a Route 53 hosted zone for the ArgoCD subdomain and outputs the nameservers to delegate to your domain registrar.
+Creates a public Route 53 hosted zone for the subdomain and outputs the nameservers to delegate to your domain registrar.
 
 ## Purpose
 
-Run this **once per environment** before deploying the EKS stack. The hosted zone must exist and be authoritative for the subdomain before ACM can validate the TLS certificate.
+Run this **once per environment** before deploying the EKS stack. The public hosted zone must exist and be authoritative for the subdomain before ACM can validate the TLS certificate.
+
+This bootstrap creates only the **public** zone. The EKS stack creates a matching **private** zone with the same domain name. The two zones serve different purposes:
+
+| Zone | Created by | Purpose |
+|------|-----------|---------|
+| Public | This bootstrap | Holds the ACM validation CNAME only. No A record. |
+| Private | EKS stack | Holds the A record written by ExternalDNS, pointing to the internal ALB. |
+
+From within the VPC, Route 53 private zones take precedence, so the domain resolves to the internal ALB. From the public internet, the public zone exists but has no A record.
 
 The full DNS flow is:
-1. This bootstrap creates the hosted zone and outputs 4 nameservers.
+1. This bootstrap creates the public hosted zone and outputs 4 nameservers.
 2. **Manual step**: Add those nameservers to your domain registrar as NS records for the subdomain, delegating authority to Route 53.
-3. The EKS stack then handles everything else automatically: ACM issues the TLS certificate (validated via a CNAME in the hosted zone), and the Load Balancer Controller creates an ALB and adds an Alias A record pointing the subdomain to it.
+3. The EKS stack handles everything else: ACM issues the TLS certificate (validated via a CNAME in the public zone), creates the private zone associated with the VPC, and ExternalDNS writes the A record to the private zone.
 
 ## Multi Environment DNS Setup
 
-Each environment needs its own Route 53 hosted zone so that ArgoCD can be deployed independently per env — `argocd.dev.yourdomain.com`, `argocd.staging.yourdomain.com`, `argocd.prod.yourdomain.com` — without zones or state clashing. Run this bootstrap once per environment, delegate the NS records, then deploy the [EKS stack](../../examples/stacks/eks/) which will pick up the zone automatically via a data source.
+Each environment needs its own Route 53 hosted zone so that the subdomain can be deployed independently per env — `argocd.dev.yourdomain.com`, `argocd.staging.yourdomain.com`, `argocd.prod.yourdomain.com` — without zones or state clashing. Run this bootstrap once per environment, delegate the NS records, then deploy the [EKS stack](../../examples/stacks/eks/) which will pick up the public zone automatically via a data source and create the private zone.
 
 ## Structure
 
@@ -113,4 +122,4 @@ Delegation is working when 4 AWS nameservers appear in the `ANSWER SECTION`. Pro
 
 ### Next Steps
 
-With delegation in place, deploy the EKS stack normally. ACM certificate validation and the Route 53 Alias A record for the ALB are created automatically. No further manual DNS steps are required.
+With delegation in place, deploy the EKS stack normally. ACM certificate validation, private zone creation, and the ExternalDNS A record pointing to the internal ALB are all handled automatically. No further manual DNS steps are required.

--- a/pipelines/examples/stacks/eks/terragrunt.stack.hcl
+++ b/pipelines/examples/stacks/eks/terragrunt.stack.hcl
@@ -140,7 +140,7 @@ unit "argocd" {
           controller       = "aws"
           ingressClassName = "alb"
           annotations = {
-            "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
+            "alb.ingress.kubernetes.io/scheme"           = "internal"
             "alb.ingress.kubernetes.io/target-type"      = "ip"
             "alb.ingress.kubernetes.io/backend-protocol" = "HTTP"
             "alb.ingress.kubernetes.io/listen-ports"     = "[{\"HTTP\":80}, {\"HTTPS\":443}]"
@@ -153,6 +153,16 @@ unit "argocd" {
         }
       }
     }
+  }
+}
+
+unit "route53_hosted_zone_private" {
+  source = "${get_repo_root()}/units/eks/route53_hosted_zone_private"
+  path   = "eks/route53_hosted_zone_private"
+
+  values = {
+    version = local.version
+    comment = "Managed by Terraform"
   }
 }
 
@@ -181,9 +191,11 @@ unit "external_dns" {
         name = "aws"
       }
       registry = "txt"
-      # Allow to create and delete records
       policy   = "sync"
       logLevel = "info"
+      extraArgs = {
+        "aws-zone-type" = "private"
+      }
     }
   }
 }

--- a/units/eks/addons/argocd/terragrunt.hcl
+++ b/units/eks/addons/argocd/terragrunt.hcl
@@ -60,8 +60,8 @@ dependency "acm_certificate" {
   mock_outputs_allowed_terraform_commands = ["init", "plan", "validate", "graph", "destroy"]
 }
 
-dependency "route53_hosted_zone" {
-  config_path = "../../route53_hosted_zone"
+dependency "route53_hosted_zone_private" {
+  config_path = "../../route53_hosted_zone_private"
   mock_outputs = {
     domain_name = "mock.example.com"
   }
@@ -84,7 +84,7 @@ inputs = {
     },
     {
       name  = "global.domain"
-      value = dependency.route53_hosted_zone.outputs.domain_name
+      value = dependency.route53_hosted_zone_private.outputs.domain_name
     }
   ]
 }

--- a/units/eks/addons/external_dns/terragrunt.hcl
+++ b/units/eks/addons/external_dns/terragrunt.hcl
@@ -57,8 +57,8 @@ dependency "iam_role_external_dns" {
   skip_outputs = true
 }
 
-dependency "route53_hosted_zone" {
-  config_path = "../../route53_hosted_zone"
+dependency "route53_hosted_zone_private" {
+  config_path = "../../route53_hosted_zone_private"
   mock_outputs = {
     domain_name = "mock.example.com"
   }
@@ -92,7 +92,7 @@ inputs = {
     },
     {
       name  = "domainFilters[0]"
-      value = dependency.route53_hosted_zone.outputs.domain_name
+      value = dependency.route53_hosted_zone_private.outputs.domain_name
     }
   ]
 }

--- a/units/eks/route53_hosted_zone_private/terragrunt.hcl
+++ b/units/eks/route53_hosted_zone_private/terragrunt.hcl
@@ -1,0 +1,36 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+locals {
+  environment_hcl = find_in_parent_folders("environment.hcl")
+  environment     = read_terragrunt_config(local.environment_hcl).locals.environment
+
+  dns_config_hcl = find_in_parent_folders("dns_config.hcl")
+  base_domain    = read_terragrunt_config(local.dns_config_hcl).locals.base_domain
+  subdomain      = read_terragrunt_config(local.dns_config_hcl).locals.subdomain
+  domain_name    = "${local.subdomain}.${local.environment}.${local.base_domain}"
+}
+
+terraform {
+  source = "git::git@github.com:ConsciousML/terragrunt-template-catalog-eks.git//modules/route53_hosted_zone?ref=${values.version}"
+}
+
+dependency "vpc" {
+  config_path = "../../vpc"
+  mock_outputs = {
+    vpc_id = "mock-vpc-id"
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "plan", "validate", "graph", "destroy"]
+}
+
+inputs = {
+  create       = true
+  private_zone = true
+  vpc_id       = dependency.vpc.outputs.vpc_id
+  name         = local.domain_name
+  comment      = values.comment
+  tags = {
+    environment = local.environment
+  }
+}


### PR DESCRIPTION
- Change ALB scheme from internet-facing to internal
- Add private Route 53 hosted zone unit (VPC-scoped, no NS delegation)
- Extend route53_hosted_zone module with vpc_id and private_zone variables
- Scope ExternalDNS to private zones via aws-zone-type=private
- Wire argocd and external_dns to use the private zone for domain resolution
- Update setup_dns README to document the dual-zone pattern

Closes #27 